### PR TITLE
fix: Installed pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	# Make sure to compile files after any other files they include!
 	$(PIP_COMPILE) --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	$(PIP_COMPILE) -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	$(PIP_COMPILE) -o requirements/base.txt requirements/base.in
 	$(PIP_COMPILE) -o requirements/test.txt requirements/test.in
 	$(PIP_COMPILE) -o requirements/ci.txt requirements/ci.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,7 +29,6 @@ certifi==2022.5.18.1
 cffi==1.15.0
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
 charset-normalizer==2.0.12
     # via
@@ -65,10 +64,6 @@ coverage[toml]==6.4.1
     #   -r requirements/test.txt
     #   codecov
     #   pytest-cov
-cryptography==37.0.2
-    # via
-    #   -r requirements/test.txt
-    #   secretstorage
 ddt==1.5.0
     # via -r requirements/test.txt
 dill==0.3.5.1
@@ -126,16 +121,11 @@ isort==5.10.1
     # via
     #   -r requirements/test.txt
     #   pylint
-jeepney==0.8.0
-    # via
-    #   -r requirements/test.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
     #   code-annotations
-keyring==23.5.1
+keyring==23.6.0
     # via
     #   -r requirements/test.txt
     #   twine
@@ -291,10 +281,6 @@ rich==12.4.4
     # via
     #   -r requirements/test.txt
     #   twine
-secretstorage==3.3.2
-    # via
-    #   -r requirements/test.txt
-    #   keyring
 six==1.16.0
     # via
     #   -r requirements/ci.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -23,7 +23,6 @@ certifi==2022.5.18.1
 cffi==1.15.0
     # via
     #   -r requirements/base.txt
-    #   cryptography
     #   pynacl
 charset-normalizer==2.0.12
     # via
@@ -44,8 +43,6 @@ commonmark==0.9.1
     # via rich
 coverage[toml]==6.4.1
     # via pytest-cov
-cryptography==37.0.2
-    # via secretstorage
 ddt==1.5.0
     # via -r requirements/test.in
 dill==0.3.5.1
@@ -83,13 +80,9 @@ iniconfig==1.1.1
     # via pytest
 isort==5.10.1
     # via pylint
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via code-annotations
-keyring==23.5.1
+keyring==23.6.0
     # via twine
 lazy-object-proxy==1.7.1
     # via astroid
@@ -186,8 +179,6 @@ rfc3986==2.0.0
     # via twine
 rich==12.4.4
     # via twine
-secretstorage==3.3.2
-    # via keyring
 six==1.16.0
     # via
     #   bleach


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.

JIRA: https://2u-internal.atlassian.net/browse/BOM-3454