### PR TITLE
fix: remove tox-battery requirement

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ edx-django-utils==5.9.0
     # via -r requirements/base.in
 idna==3.6
     # via requests
-newrelic==9.2.0
+newrelic==9.3.0
     # via edx-django-utils
 pbr==6.0.0
     # via stevedore

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,4 +2,3 @@
 -c constraints.txt
 
 tox                       # Virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,6 +4,12 @@
 #
 #    make upgrade
 #
+cachetools==5.3.2
+    # via tox
+chardet==5.2.0
+    # via tox
+colorama==0.4.6
+    # via tox
 distlib==0.3.7
     # via virtualenv
 filelock==3.13.1
@@ -14,26 +20,19 @@ packaging==23.2
     # via
     #   pyproject-api
     #   tox
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   tox
     #   virtualenv
 pluggy==1.3.0
     # via tox
-py==1.11.0
-    # via tox
-six==1.16.0
+pyproject-api==1.6.1
     # via tox
 tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==3.28.0
-    # via
-    #   -r requirements/ci.in
-    #   tox-battery
-tox-battery==0.6.2
+tox==4.11.4
     # via -r requirements/ci.in
-virtualenv==20.24.7
+virtualenv==20.25.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,6 +17,10 @@ build==1.0.3
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
+cachetools==5.3.2
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 certifi==2023.11.17
     # via
     #   -r requirements/test.txt
@@ -24,8 +28,11 @@ certifi==2023.11.17
 cffi==1.16.0
     # via
     #   -r requirements/test.txt
-    #   cryptography
     #   pynacl
+chardet==5.2.0
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 charset-normalizer==3.3.2
     # via
     #   -r requirements/test.txt
@@ -47,15 +54,15 @@ code-annotations==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
+colorama==0.4.6
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 coverage[toml]==7.3.2
     # via
     #   -r requirements/test.txt
     #   coverage
     #   pytest-cov
-cryptography==41.0.7
-    # via
-    #   -r requirements/test.txt
-    #   secretstorage
 ddt==1.7.0
     # via -r requirements/test.txt
 dill==0.3.7
@@ -98,13 +105,13 @@ filelock==3.13.1
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-freezegun==1.2.2
+freezegun==1.3.1
     # via -r requirements/test.txt
 idna==3.6
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
@@ -127,11 +134,6 @@ jaraco-classes==3.3.0
     # via
     #   -r requirements/test.txt
     #   keyring
-jeepney==0.8.0
-    # via
-    #   -r requirements/test.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via
     #   -r requirements/test.txt
@@ -160,11 +162,11 @@ more-itertools==10.1.0
     # via
     #   -r requirements/test.txt
     #   jaraco-classes
-newrelic==9.2.0
+newrelic==9.3.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-nh3==0.2.14
+nh3==0.2.15
     # via
     #   -r requirements/test.txt
     #   readme-renderer
@@ -174,6 +176,7 @@ packaging==23.2
     #   -r requirements/pip-tools.txt
     #   -r requirements/test.txt
     #   build
+    #   pyproject-api
     #   pytest
     #   tox
 pbr==6.0.0
@@ -186,12 +189,12 @@ pkginfo==1.9.6
     # via
     #   -r requirements/test.txt
     #   twine
-platformdirs==3.11.0
+platformdirs==4.1.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   pylint
+    #   tox
     #   virtualenv
 pluggy==1.3.0
     # via
@@ -203,10 +206,6 @@ psutil==5.9.6
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-py==1.11.0
-    # via
-    #   -r requirements/ci.txt
-    #   tox
 pycodestyle==2.11.1
     # via -r requirements/test.txt
 pycparser==2.21
@@ -244,6 +243,10 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
+pyproject-api==1.6.1
+    # via
+    #   -r requirements/ci.txt
+    #   tox
 pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
@@ -299,17 +302,11 @@ rich==13.7.0
     # via
     #   -r requirements/test.txt
     #   twine
-secretstorage==3.3.3
-    # via
-    #   -r requirements/test.txt
-    #   keyring
 six==1.16.0
     # via
-    #   -r requirements/ci.txt
     #   -r requirements/test.txt
     #   edx-lint
     #   python-dateutil
-    #   tox
 slumber==0.7.1
     # via -r requirements/test.txt
 sqlparse==0.4.4
@@ -334,6 +331,7 @@ tomli==2.0.1
     #   coverage
     #   pip-tools
     #   pylint
+    #   pyproject-api
     #   pyproject-hooks
     #   pytest
     #   tox
@@ -341,11 +339,7 @@ tomlkit==0.12.3
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==3.28.0
-    # via
-    #   -r requirements/ci.txt
-    #   tox-battery
-tox-battery==0.6.2
+tox==4.11.4
     # via -r requirements/ci.txt
 twine==4.0.2
     # via -r requirements/test.txt
@@ -362,7 +356,7 @@ urllib3==2.1.0
     #   requests
     #   responses
     #   twine
-virtualenv==20.24.7
+virtualenv==20.25.0
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ build==1.0.3
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via build
 packaging==23.2
     # via build

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -19,7 +19,6 @@ certifi==2023.11.17
 cffi==1.16.0
     # via
     #   -r requirements/base.txt
-    #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via
@@ -40,8 +39,6 @@ coverage[toml]==7.3.2
     # via
     #   coverage
     #   pytest-cov
-cryptography==41.0.7
-    # via secretstorage
 ddt==1.7.0
     # via -r requirements/test.in
 dill==0.3.7
@@ -68,13 +65,13 @@ edx-lint==5.3.6
     # via -r requirements/test.in
 exceptiongroup==1.2.0
     # via pytest
-freezegun==1.2.2
+freezegun==1.3.1
     # via -r requirements/test.in
 idna==3.6
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==6.8.0
+importlib-metadata==7.0.0
     # via
     #   keyring
     #   twine
@@ -86,10 +83,6 @@ isort==5.12.0
     # via pylint
 jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.2
     # via code-annotations
 keyring==24.3.0
@@ -104,11 +97,11 @@ mdurl==0.1.2
     # via markdown-it-py
 more-itertools==10.1.0
     # via jaraco-classes
-newrelic==9.2.0
+newrelic==9.3.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-nh3==0.2.14
+nh3==0.2.15
     # via readme-renderer
 packaging==23.2
     # via pytest
@@ -118,10 +111,8 @@ pbr==6.0.0
     #   stevedore
 pkginfo==1.9.6
     # via twine
-platformdirs==3.11.0
-    # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   pylint
+platformdirs==4.1.0
+    # via pylint
 pluggy==1.3.0
     # via pytest
 psutil==5.9.6
@@ -195,8 +186,6 @@ rfc3986==2.0.0
     # via twine
 rich==13.7.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   edx-lint

--- a/tox.ini
+++ b/tox.ini
@@ -21,5 +21,6 @@ setenv =
 commands = 
     pycodestyle --config=.pep8 edx_rest_api_client
     pylint --rcfile=pylintrc edx_rest_api_client
-    twine check {distdir}/*
+    python setup.py bdist_wheel
+    twine check dist/*
 


### PR DESCRIPTION
## Description
- Remove `tox-battery` package as it is not needed for `tox>4` anymore.