### PR TITLE
fix: fix make upgrade job

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,53 +4,49 @@
 #
 #    make upgrade
 #
-asgiref==3.8.1
+asgiref==3.9.1
     # via django
-certifi==2025.1.31
+certifi==2025.8.3
     # via requests
 cffi==1.17.1
     # via pynacl
-charset-normalizer==3.4.1
+charset-normalizer==3.4.3
     # via requests
-click==8.1.8
+click==8.2.1
     # via edx-django-utils
-django==4.2.22
+django==4.2.23
     # via
-    #   -c common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   django-crum
     #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via edx-django-utils
-django-waffle==4.2.0
+django-waffle==5.0.0
     # via edx-django-utils
-edx-django-utils==7.2.0
-    # via -r base.in
+edx-django-utils==8.0.0
+    # via -r requirements/base.in
 idna==3.10
     # via requests
-newrelic==10.7.0
-    # via edx-django-utils
-pbr==6.1.1
+pbr==7.0.1
     # via stevedore
 psutil==7.0.0
     # via edx-django-utils
 pycparser==2.22
     # via cffi
 pyjwt==2.10.1
-    # via -r base.in
+    # via -r requirements/base.in
 pynacl==1.5.0
     # via edx-django-utils
-requests==2.32.3
-    # via -r base.in
+requests==2.32.5
+    # via -r requirements/base.in
 sqlparse==0.5.3
     # via django
 stevedore==5.4.1
     # via edx-django-utils
-urllib3==2.2.3
-    # via
-    #   -c common_constraints.txt
-    #   requests
+urllib3==2.5.0
+    # via requests
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==76.1.0
+setuptools==80.9.0
     # via pbr

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,31 +4,35 @@
 #
 #    make upgrade
 #
-cachetools==5.5.2
+cachetools==6.1.0
     # via tox
 chardet==5.2.0
     # via tox
 colorama==0.4.6
     # via tox
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   tox
     #   virtualenv
 packaging==24.2
     # via
+    #   -c requirements/constraints.txt
     #   pyproject-api
     #   tox
 platformdirs==4.3.6
     # via
+    #   -c requirements/constraints.txt
     #   tox
     #   virtualenv
 pluggy==1.5.0
-    # via tox
+    # via
+    #   -c requirements/constraints.txt
+    #   tox
 pyproject-api==1.9.0
     # via tox
-tox==4.24.2
+tox==4.27.0
     # via -r requirements/ci.in
-virtualenv==20.29.3
+virtualenv==20.34.0
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -24,13 +24,6 @@ Django<5.0
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
 
-# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
-django-simple-history==3.0.0
-
 # Cause: https://github.com/openedx/edx-lint/issues/458
 # This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
 pip<24.3
-
-# Cause: https://github.com/openedx/edx-lint/issues/475
-# This can be unpinned once https://github.com/openedx/edx-lint/issues/476 has been resolved.
-urllib3<2.3.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -12,7 +12,8 @@
 -c common_constraints.txt
 
 # pinning version to resolve requirements upgrade conflicts
-packaging<25.0
 # pylint requires platformdirs==4.3.8, pluggy==1.6.0 which conflicts with tox requirements
+# issue to unpin these dependencies https://github.com/openedx/edx-rest-api-client/issues/379
+packaging<25.0
 platformdirs<4.3.7
 pluggy<1.6.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,9 @@
 
 # Common constraints for edx repos
 -c common_constraints.txt
+
+# pinning version to resolve requirements upgrade conflicts
+packaging<25.0
+# pylint requires platformdirs==4.3.8, pluggy==1.6.0 which conflicts with tox requirements
+platformdirs<4.3.7
+pluggy<1.6.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,48 +4,47 @@
 #
 #    make upgrade
 #
-asgiref==3.8.1
+asgiref==3.9.1
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   django
-astroid==3.3.9
+astroid==3.3.11
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
 backports-tarfile==1.2.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   jaraco-context
-build==1.2.2.post1
+build==1.3.0
     # via
-    #   -r pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   pip-tools
 cachetools==5.5.2
     # via
-    #   -r ci.txt
+    #   -r requirements/ci.txt
     #   tox
-certifi==2025.1.31
+certifi==2025.8.3
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   requests
 cffi==1.17.1
     # via
-    #   -r test.txt
-    #   cryptography
+    #   -r requirements/test.txt
     #   pynacl
 chardet==5.2.0
     # via
-    #   -r ci.txt
+    #   -r requirements/ci.txt
     #   tox
-charset-normalizer==3.4.1
+charset-normalizer==3.4.3
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   requests
-click==8.1.8
+click==8.2.1
     # via
-    #   -r pip-tools.txt
-    #   -r test.txt
+    #   -r requirements/pip-tools.txt
+    #   -r requirements/test.txt
     #   click-log
     #   code-annotations
     #   edx-django-utils
@@ -53,322 +52,310 @@ click==8.1.8
     #   pip-tools
 click-log==0.4.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-lint
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-lint
 colorama==0.4.6
     # via
-    #   -r ci.txt
+    #   -r requirements/ci.txt
     #   tox
-coverage[toml]==7.7.0
+coverage[toml]==7.10.4
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
-cryptography==44.0.2
-    # via
-    #   -r test.txt
-    #   secretstorage
 ddt==1.7.2
-    # via -r test.txt
-dill==0.3.9
+    # via -r requirements/test.txt
+dill==0.4.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   pylint
 distlib==0.3.9
     # via
-    #   -r ci.txt
+    #   -r requirements/ci.txt
     #   virtualenv
-django==4.2.22
+django==4.2.23
     # via
-    #   -c common_constraints.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test.txt
     #   django-crum
     #   django-waffle
     #   edx-django-utils
 django-crum==0.7.9
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
-django-waffle==4.2.0
+django-waffle==5.0.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
-docutils==0.21.2
+docutils==0.22
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   readme-renderer
-edx-django-utils==7.2.0
-    # via -r test.txt
+edx-django-utils==8.0.0
+    # via -r requirements/test.txt
 edx-lint==5.6.0
-    # via -r test.txt
+    # via -r requirements/test.txt
 filelock==3.18.0
     # via
-    #   -r ci.txt
+    #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-freezegun==1.5.1
-    # via -r test.txt
+freezegun==1.5.5
+    # via -r requirements/test.txt
 id==1.5.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   twine
 idna==3.10
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   requests
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   keyring
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   pytest
 isort==6.0.1
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   pylint
 jaraco-classes==3.4.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   keyring
 jaraco-context==6.0.1
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.3.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   keyring
-jeepney==0.9.0
-    # via
-    #   -r test.txt
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   code-annotations
 keyring==25.6.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   twine
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   rich
 markupsafe==3.0.2
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   jinja2
 mccabe==0.7.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   pylint
 mdurl==0.1.2
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   markdown-it-py
-more-itertools==10.6.0
+more-itertools==10.7.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   jaraco-classes
     #   jaraco-functools
-newrelic==10.7.0
+nh3==0.3.0
     # via
-    #   -r test.txt
-    #   edx-django-utils
-nh3==0.2.21
-    # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   readme-renderer
 packaging==24.2
     # via
-    #   -r ci.txt
-    #   -r pip-tools.txt
-    #   -r test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
+    #   -r requirements/test.txt
     #   build
     #   pyproject-api
     #   pytest
     #   tox
     #   twine
-pbr==6.1.1
+pbr==7.0.1
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   stevedore
-pip-tools==7.4.1
-    # via -r pip-tools.txt
+pip-tools==7.5.0
+    # via -r requirements/pip-tools.txt
 platformdirs==4.3.6
     # via
-    #   -r ci.txt
-    #   -r test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/ci.txt
+    #   -r requirements/test.txt
     #   pylint
     #   tox
     #   virtualenv
 pluggy==1.5.0
     # via
-    #   -r ci.txt
-    #   -r test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/ci.txt
+    #   -r requirements/test.txt
     #   pytest
+    #   pytest-cov
     #   tox
 psutil==7.0.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
-pycodestyle==2.12.1
-    # via -r test.txt
+pycodestyle==2.14.0
+    # via -r requirements/test.txt
 pycparser==2.22
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   cffi
-pygments==2.19.1
+pygments==2.19.2
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
+    #   pytest
     #   readme-renderer
     #   rich
 pyjwt==2.10.1
-    # via -r test.txt
-pylint==3.3.5
+    # via -r requirements/test.txt
+pylint==3.3.8
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-lint
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
 pylint-celery==0.3
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-lint
 pylint-django==2.6.1
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
 pynacl==1.5.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 pyproject-api==1.9.0
     # via
-    #   -r ci.txt
+    #   -r requirements/ci.txt
     #   tox
 pyproject-hooks==1.2.0
     # via
-    #   -r pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==8.3.5
+pytest==8.4.1
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.0.0
-    # via -r test.txt
-pytest-django==4.10.0
-    # via -r test.txt
+pytest-cov==6.2.1
+    # via -r requirements/test.txt
+pytest-django==4.11.1
+    # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   freezegun
 python-slugify==8.0.4
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   code-annotations
 pyyaml==6.0.2
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   responses
 readme-renderer==44.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   twine
-requests==2.32.3
+requests==2.32.5
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   id
     #   requests-toolbelt
     #   responses
     #   twine
 requests-toolbelt==1.0.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   twine
-responses==0.25.7
-    # via -r test.txt
+responses==0.25.8
+    # via -r requirements/test.txt
 rfc3986==2.0.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   twine
-rich==13.9.4
+rich==14.1.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   twine
-secretstorage==3.3.3
-    # via
-    #   -r test.txt
-    #   keyring
 six==1.17.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   edx-lint
     #   python-dateutil
 sqlparse==0.5.3
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-utils
 text-unidecode==1.3
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.2
+tomlkit==0.13.3
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   pylint
 tox==4.24.2
-    # via -r ci.txt
+    # via -r requirements/ci.txt
 twine==6.1.0
-    # via -r test.txt
-urllib3==2.2.3
+    # via -r requirements/test.txt
+urllib3==2.5.0
     # via
-    #   -c common_constraints.txt
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   requests
     #   responses
     #   twine
 virtualenv==20.29.3
     # via
-    #   -r ci.txt
+    #   -r requirements/ci.txt
     #   tox
 wheel==0.45.1
     # via
-    #   -r pip-tools.txt
+    #   -r requirements/pip-tools.txt
     #   pip-tools
-zipp==3.21.0
+zipp==3.23.0
     # via
-    #   -r test.txt
+    #   -r requirements/test.txt
     #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c common_constraints.txt
-    #   -r pip-tools.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/pip-tools.txt
     #   pip-tools
-setuptools==76.1.0
+setuptools==80.9.0
     # via
-    #   -r pip-tools.txt
-    #   -r test.txt
+    #   -r requirements/pip-tools.txt
+    #   -r requirements/test.txt
     #   pbr
     #   pip-tools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,13 +4,15 @@
 #
 #    make upgrade
 #
-build==1.2.2.post1
+build==1.3.0
     # via pip-tools
-click==8.1.8
+click==8.2.1
     # via pip-tools
 packaging==24.2
-    # via build
-pip-tools==7.4.1
+    # via
+    #   -c requirements/constraints.txt
+    #   build
+pip-tools==7.5.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.2.0
     # via
@@ -24,5 +26,5 @@ pip==24.2
     # via
     #   -c requirements/common_constraints.txt
     #   pip-tools
-setuptools==76.1.0
+setuptools==80.9.0
     # via pip-tools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -12,5 +12,5 @@ pip==24.2
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==76.1.0
+setuptools==80.9.0
     # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,30 +4,29 @@
 #
 #    make upgrade
 #
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -r requirements/base.txt
     #   django
-astroid==3.3.9
+astroid==3.3.11
     # via
     #   pylint
     #   pylint-celery
 backports-tarfile==1.2.0
     # via jaraco-context
-certifi==2025.1.31
+certifi==2025.8.3
     # via
     #   -r requirements/base.txt
     #   requests
 cffi==1.17.1
     # via
     #   -r requirements/base.txt
-    #   cryptography
     #   pynacl
-charset-normalizer==3.4.1
+charset-normalizer==3.4.3
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.1.8
+click==8.2.1
     # via
     #   -r requirements/base.txt
     #   click-log
@@ -36,15 +35,13 @@ click==8.1.8
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via edx-lint
-coverage[toml]==7.7.0
+coverage[toml]==7.10.4
     # via pytest-cov
-cryptography==44.0.2
-    # via secretstorage
 ddt==1.7.2
     # via -r requirements/test.in
-dill==0.3.9
+dill==0.4.0
     # via pylint
     # via
     #   -c requirements/common_constraints.txt
@@ -56,17 +53,17 @@ django-crum==0.7.9
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django-waffle==4.2.0
+django-waffle==5.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-docutils==0.21.2
+docutils==0.22
     # via readme-renderer
-edx-django-utils==7.2.0
+edx-django-utils==8.0.0
     # via -r requirements/base.txt
 edx-lint==5.6.0
     # via -r requirements/test.in
-freezegun==1.5.1
+freezegun==1.5.5
     # via -r requirements/test.in
 id==1.5.0
     # via twine
@@ -74,9 +71,9 @@ idna==3.10
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==8.6.1
+importlib-metadata==8.7.0
     # via keyring
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
 isort==6.0.1
     # via pylint
@@ -84,17 +81,13 @@ jaraco-classes==3.4.0
     # via keyring
 jaraco-context==6.0.1
     # via keyring
-jaraco-functools==4.1.0
+jaraco-functools==4.3.0
     # via keyring
-jeepney==0.9.0
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6
     # via code-annotations
 keyring==25.6.0
     # via twine
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.2
     # via jinja2
@@ -102,45 +95,48 @@ mccabe==0.7.0
     # via pylint
 mdurl==0.1.2
     # via markdown-it-py
-more-itertools==10.6.0
+more-itertools==10.7.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-newrelic==10.7.0
-    # via
-    #   -r requirements/base.txt
-    #   edx-django-utils
-nh3==0.2.21
+nh3==0.3.0
     # via readme-renderer
 packaging==24.2
     # via
+    #   -c requirements/constraints.txt
     #   pytest
     #   twine
-pbr==6.1.1
+pbr==7.0.1
     # via
     #   -r requirements/base.txt
     #   stevedore
 platformdirs==4.3.6
-    # via pylint
+    # via
+    #   -c requirements/constraints.txt
+    #   pylint
 pluggy==1.5.0
-    # via pytest
+    # via
+    #   -c requirements/constraints.txt
+    #   pytest
+    #   pytest-cov
 psutil==7.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycodestyle==2.12.1
+pycodestyle==2.14.0
     # via -r requirements/test.in
 pycparser==2.22
     # via
     #   -r requirements/base.txt
     #   cffi
-pygments==2.19.1
+pygments==2.19.2
     # via
+    #   pytest
     #   readme-renderer
     #   rich
 pyjwt==2.10.1
     # via -r requirements/base.txt
-pylint==3.3.5
+pylint==3.3.8
     # via
     #   edx-lint
     #   pylint-celery
@@ -150,7 +146,7 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.6.1
     # via edx-lint
-pylint-plugin-utils==0.8.2
+pylint-plugin-utils==0.9.0
     # via
     #   pylint-celery
     #   pylint-django
@@ -158,13 +154,13 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==8.3.5
+pytest==8.4.1
     # via
     #   pytest-cov
     #   pytest-django
-pytest-cov==6.0.0
+pytest-cov==6.2.1
     # via -r requirements/test.in
-pytest-django==4.10.0
+pytest-django==4.11.1
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via freezegun
@@ -176,7 +172,7 @@ pyyaml==6.0.2
     #   responses
 readme-renderer==44.0
     # via twine
-requests==2.32.3
+requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   id
@@ -185,14 +181,12 @@ requests==2.32.3
     #   twine
 requests-toolbelt==1.0.0
     # via twine
-responses==0.25.7
+responses==0.25.8
     # via -r requirements/test.in
 rfc3986==2.0.0
     # via twine
-rich==13.9.4
+rich==14.1.0
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.17.0
     # via
     #   edx-lint
@@ -208,22 +202,21 @@ stevedore==5.4.1
     #   edx-django-utils
 text-unidecode==1.3
     # via python-slugify
-tomlkit==0.13.2
+tomlkit==0.13.3
     # via pylint
 twine==6.1.0
     # via -r requirements/test.in
-urllib3==2.2.3
+urllib3==2.5.0
     # via
-    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   requests
     #   responses
     #   twine
-zipp==3.21.0
+zipp==3.23.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==76.1.0
+setuptools==80.9.0
     # via
     #   -r requirements/base.txt
     #   pbr


### PR DESCRIPTION
## Description
- Requirements upgrade job was failing due to an incompatibility between dependencies. 
- Fixed the `make upgrade` build by pinning some dependencies.